### PR TITLE
cmd/si-dump: dump status, readout, or config

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,4 +1,4 @@
-ALL  = dump-config test_app image
+ALL  = si-dump test_app image
 
 GTK_CFLAGS := $(shell pkg-config --cflags gtk+-2.0)
 GTK_LIBS := $(shell pkg-config --libs gtk+-2.0)


### PR DESCRIPTION
Rename dump-config to si-dump, and allow three config,
readout, or status to be dumped, depending on argument:

si-dump L   - dumps configuraiton parameers
si-dump H   - dumps readout parametrs
si-dump I   - dumps camera status