### PR TITLE
driver: get working on amd64 architecture

### DIFF
--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -1,6 +1,6 @@
 /*
 
-Linux 2.6 Driver for the
+Linux Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -1,6 +1,6 @@
-/* 
+/*
 
-Linux 2.6 Driver for the 
+Linux 2.6 Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen
@@ -50,7 +50,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
   if( !dev )
     return -EIO;
 
-  
+
 //  if( dev->verbose )
 //    printk("SI ioctl %d\n",  _IOC_SIZE(cmd) );
 
@@ -61,7 +61,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
     case SI_IOCTL_RESET:
       ret = si_reset( dev ); /* parameter ignored */
       break;
-      
+
     case SI_IOCTL_SERIAL_IN_STATUS:
       {
       int status;
@@ -97,7 +97,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
       break;
     case SI_IOCTL_SET_SERIAL:
 
-      if(copy_from_user( &serial_param, (struct SI_SERIAL_PARAM *)args, 
+      if(copy_from_user( &serial_param, (struct SI_SERIAL_PARAM *)args,
         sizeof(struct SI_SERIAL_PARAM)))
           return (-EFAULT);
 
@@ -112,7 +112,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
       si_uart_clear( dev );
       ret = 0;
       break;
-    
+
     case SI_IOCTL_SERIAL_BREAK:
       {
         int tim;
@@ -120,7 +120,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
         if( (ret = get_user( tim, (int __user *)args ))<0 )
           break;
 
-        if (tim < 0 || tim > 1000) 
+        if (tim < 0 || tim > 1000)
           tim = 1000;        // limit to 1 second
 
         if( dev->verbose& SI_VERBOSE_SERIAL )
@@ -130,13 +130,13 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
       }
       break;
 
-      
+
     // DMA related entries
     case SI_IOCTL_DMA_INIT:
       if( dev->verbose )
         printk("SI IOCTL_DMA_INIT\n");
 
-      if(copy_from_user( &dev->dma_cfg, (struct SI_DMA_CONFIG *)args, 
+      if(copy_from_user( &dev->dma_cfg, (struct SI_DMA_CONFIG *)args,
         sizeof(struct SI_DMA_CONFIG))) {
           ret = -EFAULT;
           break;
@@ -144,7 +144,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
       ret = si_config_dma( dev );
 
       break;
-    
+
     case SI_IOCTL_DMA_START:
       if( dev->verbose )
         printk("SI_IOCTL_DMA_START\n");
@@ -180,7 +180,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
         sizeof(struct SI_DMA_STATUS)))
           ret = -EFAULT;
       break;
-      
+
     case SI_IOCTL_DMA_ABORT:
       if( dev->verbose )
         printk("SI_IOCTL_DMA_ABORT\n");
@@ -213,7 +213,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
       if( (ret = si_wait_vmaclose( dev )) ) { /* make sure munmap before free */
         printk("SI freemem timeout waiting for munmap\n");
         return ret;
-      } 
+      }
 
       if( dev->sgl ) {
         si_stop_dma(dev, NULL);
@@ -243,7 +243,7 @@ int si_reset(struct SIDEVICE *dev)
   if( dev->verbose )
     printk("SI master local reset\n" );
   /* do the master reset local bus */
-  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, 0 );  
+  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, 0 );
   return 0;
 }
 

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -238,8 +238,7 @@ long si_ioctl( struct file *filp, unsigned int cmd, unsigned long  args )
 }
 
 
-int si_reset( dev )
-struct SIDEVICE *dev;
+int si_reset(struct SIDEVICE *dev)
 {
   if( dev->verbose )
     printk("SI master local reset\n" );

--- a/driver/irup.c
+++ b/driver/irup.c
@@ -1,6 +1,6 @@
 /*
 
-Linux 2.6 Driver for the
+Linux Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen

--- a/driver/irup.c
+++ b/driver/irup.c
@@ -1,6 +1,6 @@
-/* 
+/*
 
-Linux 2.6 Driver for the 
+Linux 2.6 Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen
@@ -198,7 +198,7 @@ void si_bottom_half( struct work_struct *work )
           } else
             i = 1;  // just get 1 at a time
           while (i--) {  // fill fifo as much as possible
-            UART_REG_WRITE(dev, SERIAL_TX, 
+            UART_REG_WRITE(dev, SERIAL_TX,
               dev->Uart.txbuf[dev->Uart.txget++]);
             if (dev->Uart.txget == dev->Uart.serialbufsize)
               dev->Uart.txget = 0;
@@ -253,21 +253,21 @@ void si_bottom_half( struct work_struct *work )
       /* Clear DMA interrupt and disable if done */
       PLX_REG8_WRITE( dev, PCI9054_DMA_COMMAND_STAT, (1<<3));
       /* careful not to read local bus during DMA */
-      LOCAL_REG_WRITE(dev, LOCAL_COMMAND, LC_FIFO_MRS_L );  
+      LOCAL_REG_WRITE(dev, LOCAL_COMMAND, LC_FIFO_MRS_L );
       rb_count  =  LOCAL_REG_READ(dev, LOCAL_PIX_CNT_LL) & 0xff;
       rb_count += (LOCAL_REG_READ(dev, LOCAL_PIX_CNT_ML) & 0xff) << 8;
       rb_count += (LOCAL_REG_READ(dev, LOCAL_PIX_CNT_MH) & 0xff) << 16;
       rb_count += (LOCAL_REG_READ(dev, LOCAL_PIX_CNT_HH) & 0xff) << 24;
-      if( !dev->abort_active && rb_count ) 
+      if( !dev->abort_active && rb_count )
         printk("SI bh DMA0 irup, rb_count not zero %d\n", rb_count );
       dev->rb_count = rb_count;
-       
+
     } else {
       PLX_REG8_WRITE( dev, PCI9054_DMA_COMMAND_STAT, (1<<3)|(1<<0));
     }
 
     if( dev->verbose )
-      printk("SI bh DMA0 irup, int_stat 0x%x mode 0x%x dma_stat 0x%x\n", 
+      printk("SI bh DMA0 irup, int_stat 0x%x mode 0x%x dma_stat 0x%x\n",
       int_stat, dev->irup_reg, reg );
 
     dev->dma_cur++;

--- a/driver/mmap.c
+++ b/driver/mmap.c
@@ -1,6 +1,6 @@
 /*
 
-Linux 2.6 Driver for the
+Linux Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen

--- a/driver/mmap.c
+++ b/driver/mmap.c
@@ -274,7 +274,7 @@ struct SIDEVICE *dev;
 
     last = (dma_addr_t)ch_dma & 0xfffffff0;
     setb = ((nb+1)&0x7f); /* set mem to see mmap working */
-    memset( (void *)ch->cpu, setb, sm_buflen );
+    memset( ch->cpu, setb, sm_buflen );
 
   }
 /* always wake up at the end */
@@ -371,7 +371,7 @@ struct SIDEVICE *dev;
     ch_dma = dev->sgl_pci + sizeof(struct SIDMA_SGL )*nb; /*bus side address*/
     ch->padr = (__u32)dma_buf;
     ch->ladr = local_addr;
-    ch->cpu = (__u32)cpu;
+    ch->cpu = cpu;
     ch->siz = 0;
     ch->dpr = 0;
     dev->total_allocs++;
@@ -459,7 +459,7 @@ struct SIDEVICE *dev;
       page++;
     }
 
-    dma_free_coherent(&dev->pci->dev, sm_buflen, (void *)ch->cpu, ch->padr);
+    dma_free_coherent(&dev->pci->dev, sm_buflen, ch->cpu, ch->padr);
     total_frees++;
     total_bytes += dev->dma_cfg.buflen;
   }

--- a/driver/mmap.c
+++ b/driver/mmap.c
@@ -1,6 +1,6 @@
-/* 
+/*
 
-Linux 2.6 Driver for the 
+Linux 2.6 Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen
@@ -21,9 +21,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 */
 
-/* mmap 
-   allocate the driver buffers and 
-   map it to the application 
+/* mmap
+   allocate the driver buffers and
+   map it to the application
 */
 
 #include <linux/version.h>
@@ -60,10 +60,10 @@ void si_vmaclose( struct vm_area_struct *area )
   struct SIDEVICE *dev;
 
   dev = (struct SIDEVICE *)area->vm_file->private_data;
-  
+
   if( dev->verbose )
     printk("SI vmaclose vmact %d\n", atomic_read(&dev->vmact) );
-  
+
   if( atomic_dec_and_test(&dev->vmact) )
     ;//wake_up_interruptible( &dev->mmap_block );
 
@@ -108,24 +108,24 @@ int si_vmafault( struct vm_fault *vmf )
   nbuf = off/dev->alloc_sm_buflen;
   loff = off % dev->alloc_sm_buflen;
   if( nbuf >= dev->dma_nbuf ) {
-    printk("SI fault, requested more mmap than data: nbuf %d max %d\n", 
+    printk("SI fault, requested more mmap than data: nbuf %d max %d\n",
       nbuf, dev->dma_nbuf );
     spin_unlock_irqrestore( &dev->nopage_lock, flags );
     return(VM_FAULT_SIGBUS);
   }
-  
+
   vaddr = ((unsigned char *)dev->sgl[nbuf].cpu) + loff;
 
   vmf->page = virt_to_page( vaddr );
-  get_page( vmf->page ); 
+  get_page( vmf->page );
   spin_unlock_irqrestore( &dev->nopage_lock, flags );
 
   return( 0 );
 }
 
 static struct vm_operations_struct si_vm_ops = {
-  .open  = si_vmaopen, 
-  .close = si_vmaclose, 
+  .open  = si_vmaopen,
+  .close = si_vmaclose,
   .fault = si_vmafault
 };
 
@@ -153,7 +153,7 @@ int si_mmap(struct file *filp, struct vm_area_struct *vma)
    dev->sgl holds an array of scatted gather tables
    which holds the pointers to the dma.
    An additional element, cpu is added to hold
-   the kernel side virt address of the hardware address 
+   the kernel side virt address of the hardware address
 */
 
 int si_config_dma(struct SIDEVICE *dev)
@@ -179,12 +179,12 @@ int si_config_dma(struct SIDEVICE *dev)
 
   if( dev->alloc_maxever == 0 ) { /* allocate the memory */
     if( dev->dma_cfg.total <= 0 ) {
-      printk("SI config.total %d\n", dev->dma_cfg.total ); 
+      printk("SI config.total %d\n", dev->dma_cfg.total );
       return -EIO;
     }
     if( dev->dma_cfg.maxever <= 0 )
       dev->dma_cfg.maxever = dev->dma_cfg.total;
-    
+
     dev->alloc_maxever = dev->dma_cfg.maxever;
     dev->alloc_buflen = dev->dma_cfg.buflen;
     si_alloc_memory(dev);
@@ -244,13 +244,13 @@ int si_config_dma(struct SIDEVICE *dev)
   }
 
   if( buflen != sm_buflen ) {
-    printk("SI WARNING buflen %d sm_buflen %d, not a multiple of page size\n", 
+    printk("SI WARNING buflen %d sm_buflen %d, not a multiple of page size\n",
       buflen, sm_buflen );
   }
 
   spin_lock_irqsave( &dev->dma_lock, flags );
 
-  if( dev->dma_cfg.config & SI_DMA_CONFIG_WAKEUP_EACH ) 
+  if( dev->dma_cfg.config & SI_DMA_CONFIG_WAKEUP_EACH )
     end_mask  = SIDMA_DPR_PCI_SRC| SIDMA_DPR_IRUP|SIDMA_DPR_TOPCI;
   else
     end_mask  = SIDMA_DPR_PCI_SRC| SIDMA_DPR_TOPCI;
@@ -258,7 +258,7 @@ int si_config_dma(struct SIDEVICE *dev)
   last = 0;
   if( dev->verbose )
     printk( "SI buflen %d dma_nbuf %d\n", buflen, dev->dma_nbuf );
-  
+
   local_addr = SI_LOCAL_BUSADDR;
   nchains = dev->dma_nbuf;
   for( nb=nchains-1; nb>=0; nb-- ) {
@@ -306,10 +306,10 @@ int si_alloc_memory(struct SIDEVICE *dev)
   unsigned char setb;
 
   if( dev->sgl ) {
-    printk( "SI alloc memory already allocated\n"); 
+    printk( "SI alloc memory already allocated\n");
     return -EIO;
   }
-  
+
   nbuf = dev->alloc_maxever / dev->alloc_buflen;
   if( (dev->alloc_maxever % dev->alloc_buflen) )
     nbuf++;
@@ -320,7 +320,7 @@ int si_alloc_memory(struct SIDEVICE *dev)
   if( (dev->alloc_buflen % PAGE_SIZE) == 0 )
     dev->alloc_sm_buflen = dev->alloc_buflen;
   else
-    dev->alloc_sm_buflen = dev->alloc_buflen + PAGE_SIZE - 
+    dev->alloc_sm_buflen = dev->alloc_buflen + PAGE_SIZE -
                           (dev->alloc_buflen%PAGE_SIZE);
 
   sm_buflen = dev->alloc_sm_buflen;
@@ -329,12 +329,12 @@ int si_alloc_memory(struct SIDEVICE *dev)
   dev->sgl_len = nbuf * sizeof(struct SIDMA_SGL);
   dev->sgl = dma_alloc_coherent(&dev->pci->dev, dev->sgl_len, &dev->sgl_pci,
                                 GFP_KERNEL);
-//  dev->sgl = jeff_alloc( dev->sgl_len, &dev->sgl_pci); 
+//  dev->sgl = jeff_alloc( dev->sgl_len, &dev->sgl_pci);
 
 //  spin_lock_irqsave( &dev->dma_lock, flags );
 
   if( !dev->sgl ) {
-    printk( "SI no memory allocating table\n"); 
+    printk( "SI no memory allocating table\n");
 //    spin_unlock_irqrestore( &dev->dma_lock, flags );
     return -EIO;
   }
@@ -346,15 +346,15 @@ int si_alloc_memory(struct SIDEVICE *dev)
   for( nb=nbuf-1; nb>=0; nb-- ) {
 
     cpu = dma_alloc_coherent(&dev->pci->dev, sm_buflen, &dma_buf, GFP_KERNEL);
-    //cpu = jeff_alloc( sm_buflen, &dma_buf ); 
+    //cpu = jeff_alloc( sm_buflen, &dma_buf );
     if( !cpu ) {
-      printk( "SI no memory allocating buffer %d\n", nbuf - nb); 
+      printk( "SI no memory allocating buffer %d\n", nbuf - nb);
 //      spin_unlock_irqrestore( &dev->dma_lock, flags );
-      si_free_sgl(dev);   
+      si_free_sgl(dev);
       return -EIO;
     }
 
-//   if I am already doing the pci_alloc_consistent, why do I need this 
+//   if I am already doing the pci_alloc_consistent, why do I need this
     pend = virt_to_page(cpu + buflen-1);
     page = virt_to_page(cpu);
     while( page <= pend ) {
@@ -413,7 +413,7 @@ void si_free_sgl(struct SIDEVICE *dev)
   int total_frees, total_bytes, sm_buflen;
   struct page *page, *pend;
   unsigned long flags;
-  
+
   if( !dev->sgl )
     return;
 
@@ -463,7 +463,7 @@ void si_free_sgl(struct SIDEVICE *dev)
   dev->dma_cfg.buflen = 0;
   dev->sgl_pci = 0;
   if( dev->verbose )
-    printk("SI free_sgl allocates freed %d, bytes %d\n", 
+    printk("SI free_sgl allocates freed %d, bytes %d\n",
     total_frees, total_bytes );
 
   dev->total_allocs = 0;
@@ -490,7 +490,7 @@ int si_start_dma(struct SIDEVICE *dev)
     printk("SI start_dma test mode \n");
     return 0;
   }
-  
+
   reg = PLX_REG8_READ(dev, PCI9054_DMA_COMMAND_STAT );
   if( reg & 1 ) { /* already on stop */
     printk("SI start_dma already on stopping first, dma_stat 0x%x\n", reg );
@@ -518,8 +518,8 @@ int si_start_dma(struct SIDEVICE *dev)
 
 
   // enable FIFOs
-  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, (LC_FIFO_MRS_L | LC_FIFO_PRS_L));  
-  
+  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, (LC_FIFO_MRS_L | LC_FIFO_PRS_L));
+
   atomic_set(&dev->dma_done, 0x1); // reflection of status bit
   dev->dma_cur = 0;
   dev->dma_next = 0;
@@ -571,12 +571,12 @@ int si_stop_dma(struct SIDEVICE *dev, struct SI_DMA_STATUS *status)
 
   if( cmd_stat & 1 ) {
     ret = 10; /* jiffies timeout */
-    wait_event_interruptible_timeout( 
+    wait_event_interruptible_timeout(
        dev->dma_block, (atomic_read(&dev->dma_done)&SI_DMA_STATUS_DONE), ret );
     if( !(atomic_read(&dev->dma_done)&SI_DMA_STATUS_DONE) ) {
        printk("SI timeout in abort sequence\n");
        ret = -EIO;
-    } else 
+    } else
       ret = 0;
   }
   dev->abort_active = 0;
@@ -617,11 +617,11 @@ int si_dma_next(struct SIDEVICE *dev, struct SI_DMA_STATUS *stat)
     spin_unlock_irqrestore( &dev->dma_lock, flags );
     if( next >= cur ) {
       if( !si_dma_wakeup(dev) ) {
-        wait_event_interruptible_timeout( dev->dma_block, 
+        wait_event_interruptible_timeout( dev->dma_block,
           si_dma_wakeup( dev ), tmout );
         if( si_dma_wakeup(dev) )
           ret = 0;
-        else 
+        else
           ret = -EWOULDBLOCK;
       } else {
         ret = 0;
@@ -631,11 +631,11 @@ int si_dma_next(struct SIDEVICE *dev, struct SI_DMA_STATUS *stat)
       }
   } else {
     if( !si_dma_wakeup(dev) ) {
-      wait_event_interruptible_timeout( dev->dma_block, 
+      wait_event_interruptible_timeout( dev->dma_block,
         si_dma_wakeup( dev ), tmout );
       if( si_dma_wakeup(dev) )
         ret = 0;
-      else 
+      else
         ret = -EWOULDBLOCK;
     } else  {
       ret = 0;
@@ -684,7 +684,7 @@ int si_wait_vmaclose(struct SIDEVICE *dev)
   tmout = VMACLOSE_TIMEOUT;
 
   printk("si_wait_vmaclose waiting\n");
-  wait_event_interruptible_timeout( dev->mmap_block, 
+  wait_event_interruptible_timeout( dev->mmap_block,
     (atomic_read(&dev->vmact)==0), tmout );
 
   printk("si_wait_vmaclose wakeup\n");
@@ -749,14 +749,14 @@ void *jeff_alloc(int size, dma_addr_t *pphy)
     return NULL;
   } else {
     //int i;
-    
+
    memset( km, 0, size );
 
   if( pphy )
     *pphy = (dma_addr_t) virt_to_phys( km );
 
 //    count = 0;
-    
+
 //    for( i=0; i<TEST_SIZE; i+=8192 ) {
 //       phy_ix = (unsigned int)virt_to_phys( km+i );
 //       if( phy_ix != (phy + i ))
@@ -766,9 +766,9 @@ void *jeff_alloc(int size, dma_addr_t *pphy)
 //      printk("SI TEST worked count %d\n", count );
 //    else
 //      printk("SI TEST failed count %d\n", count );
-//    
+//
 //    free_pages((unsigned long)km, order);
-  
+
     return (void *)km;
   }
 }

--- a/driver/mmap.c
+++ b/driver/mmap.c
@@ -129,9 +129,7 @@ static struct vm_operations_struct si_vm_ops = {
   .fault = si_vmafault
 };
 
-int si_mmap(filp, vma )
-struct file *filp;
-struct vm_area_struct *vma;
+int si_mmap(struct file *filp, struct vm_area_struct *vma)
 {
   struct SIDEVICE *dev;
 
@@ -158,8 +156,7 @@ struct vm_area_struct *vma;
    the kernel side virt address of the hardware address 
 */
 
-int si_config_dma( dev )
-struct SIDEVICE *dev;
+int si_config_dma(struct SIDEVICE *dev)
 {
   int nchains, nb, nbytes;
   unsigned int end_mask;
@@ -297,8 +294,7 @@ struct SIDEVICE *dev;
 
 /* allocate memory */
 
-int si_alloc_memory( dev )
-struct SIDEVICE *dev;
+int si_alloc_memory(struct SIDEVICE *dev)
 {
   int nbuf, buflen, sm_buflen, nb;
   struct SIDMA_SGL *ch;
@@ -389,8 +385,7 @@ struct SIDEVICE *dev;
  return 0;
 }
 
-void si_print_memtable( dev )
-struct SIDEVICE *dev;
+void si_print_memtable(struct SIDEVICE *dev)
 {
   int nb;
   struct SIDMA_SGL *ch;
@@ -411,8 +406,7 @@ struct SIDEVICE *dev;
   }
 }
 
-void si_free_sgl( dev )
-struct SIDEVICE *dev;
+void si_free_sgl(struct SIDEVICE *dev)
 {
   int n, nchains;
   struct SIDMA_SGL *ch, *dchain;
@@ -483,8 +477,7 @@ struct SIDEVICE *dev;
 
 /* start configured dma */
 
-int si_start_dma(dev)
-struct SIDEVICE *dev;
+int si_start_dma(struct SIDEVICE *dev)
 {
   int n_pixels;
   int rb_count;
@@ -556,9 +549,7 @@ struct SIDEVICE *dev;
 
 /* stop running dma */
 
-int si_stop_dma(dev, status )
-struct SIDEVICE *dev;
-struct SI_DMA_STATUS *status;
+int si_stop_dma(struct SIDEVICE *dev, struct SI_DMA_STATUS *status)
 {
   unsigned long flags;
   int ret;
@@ -596,9 +587,7 @@ struct SI_DMA_STATUS *status;
 
 /* no block status request */
 
-int si_dma_status(dev, stat)
-struct SIDEVICE *dev;
-struct SI_DMA_STATUS *stat;
+int si_dma_status(struct SIDEVICE *dev, struct SI_DMA_STATUS *stat)
 {
   if( !stat )
     return 0;
@@ -614,9 +603,7 @@ struct SI_DMA_STATUS *stat;
 
 /* block for next buffer complete */
 
-int si_dma_next(dev, stat)
-struct SIDEVICE *dev;
-struct SI_DMA_STATUS *stat;
+int si_dma_next(struct SIDEVICE *dev, struct SI_DMA_STATUS *stat)
 {
   int next, cur, ret, tmout;
   unsigned long flags;
@@ -667,8 +654,7 @@ struct SI_DMA_STATUS *stat;
 
 /* true if its time to wakeup dma_block */
 
-int si_dma_wakeup( dev )
-struct SIDEVICE *dev;
+int si_dma_wakeup(struct SIDEVICE *dev)
 {
   int ret;
   int done;
@@ -691,8 +677,7 @@ struct SIDEVICE *dev;
 
 /* wait for vma close */
 
-int si_wait_vmaclose( dev )
-struct SIDEVICE *dev;
+int si_wait_vmaclose(struct SIDEVICE *dev)
 {
   int tmout;
 
@@ -716,8 +701,7 @@ struct SIDEVICE *dev;
 
 /* return byte count progress */
 
-int si_dma_progress( dev )
-struct SIDEVICE *dev;
+int si_dma_progress(struct SIDEVICE *dev)
 {
   __u32 pci;
   int nb, nchains, prog;
@@ -751,9 +735,7 @@ struct SIDEVICE *dev;
 }
 
 
-void *jeff_alloc( size, pphy )
-int size;
-dma_addr_t *pphy;
+void *jeff_alloc(int size, dma_addr_t *pphy)
 {
   unsigned char *km;
 //  unsigned int phy, phy_ix;

--- a/driver/mmap.c
+++ b/driver/mmap.c
@@ -138,8 +138,8 @@ struct vm_area_struct *vma;
   dev = (struct SIDEVICE *)filp->private_data;
 
   if( dev->verbose )
-    printk("SI mmap vmact %d ptr 0x%x\n", 
-         atomic_read(&dev->vmact), (unsigned int)vma->vm_file );
+    printk("SI mmap vmact %d ptr 0x%lx\n",
+         atomic_read(&dev->vmact), (unsigned long)vma->vm_file );
 
   vma->vm_ops = &si_vm_ops;
   vma->vm_file = filp;
@@ -285,8 +285,8 @@ struct SIDEVICE *dev;
 
 
   if( dev->verbose ) {
-    printk("SI si_config_dma sgl 0x%x sgl_pci 0x%x buflen %d sm_buflen %d nbuf %d\n", 
-     (unsigned int)dev->sgl, (unsigned int)dev->sgl_pci, 
+    printk("SI si_config_dma sgl 0x%lx sgl_pci 0x%x buflen %d sm_buflen %d nbuf %d\n",
+     (unsigned long)dev->sgl, (unsigned int)dev->sgl_pci,
      buflen, sm_buflen, nbuf  );
     if( isalloc )
       si_print_memtable( dev );
@@ -404,9 +404,9 @@ struct SIDEVICE *dev;
   for( nb=0; nb< dev->dma_nbuf; nb++ ) {
     ch = &dev->sgl[nb];
     if( dev->verbose )
-      printk("SI 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x\n", 
-      (__u32)dev->sgl + sizeof(struct SIDMA_SGL)* nb, 
-        ch->padr, ch->ladr, ch->siz, ch->dpr, ch->cpu );
+      printk("SI 0x%lx 0x%x 0x%x 0x%x 0x%x 0x%lx\n",
+      (unsigned long)dev->sgl + sizeof(struct SIDMA_SGL)* nb,
+        ch->padr, ch->ladr, ch->siz, ch->dpr, (unsigned long)ch->cpu );
     ch++;
   }
 }

--- a/driver/mmap.c
+++ b/driver/mmap.c
@@ -331,7 +331,8 @@ struct SIDEVICE *dev;
   local_addr = SI_LOCAL_BUSADDR;
 
   dev->sgl_len = nbuf * sizeof(struct SIDMA_SGL);
-  dev->sgl = pci_alloc_consistent( dev->pci, dev->sgl_len, &dev->sgl_pci); 
+  dev->sgl = dma_alloc_coherent(&dev->pci->dev, dev->sgl_len, &dev->sgl_pci,
+                                GFP_KERNEL);
 //  dev->sgl = jeff_alloc( dev->sgl_len, &dev->sgl_pci); 
 
 //  spin_lock_irqsave( &dev->dma_lock, flags );
@@ -348,7 +349,7 @@ struct SIDEVICE *dev;
 
   for( nb=nbuf-1; nb>=0; nb-- ) {
 
-    cpu = pci_alloc_consistent( dev->pci, sm_buflen, &dma_buf ); 
+    cpu = dma_alloc_coherent(&dev->pci->dev, sm_buflen, &dma_buf, GFP_KERNEL);
     //cpu = jeff_alloc( sm_buflen, &dma_buf ); 
     if( !cpu ) {
       printk( "SI no memory allocating buffer %d\n", nbuf - nb); 
@@ -458,12 +459,11 @@ struct SIDEVICE *dev;
       page++;
     }
 
-    pci_free_consistent( dev->pci, sm_buflen, 
-      (void *)ch->cpu, ch->padr );
+    dma_free_coherent(&dev->pci->dev, sm_buflen, (void *)ch->cpu, ch->padr);
     total_frees++;
     total_bytes += dev->dma_cfg.buflen;
   }
-  pci_free_consistent( dev->pci, dev->sgl_len, dchain, dev->sgl_pci );
+  dma_free_coherent(&dev->pci->dev, dev->sgl_len, dchain, dev->sgl_pci);
   total_frees++;
   total_bytes += dev->sgl_len;
   dev->dma_cfg.buflen = 0;

--- a/driver/module.c
+++ b/driver/module.c
@@ -1,6 +1,6 @@
 /*
 
-Linux 2.6 Driver for the
+Linux Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen

--- a/driver/module.c
+++ b/driver/module.c
@@ -137,11 +137,8 @@ struct file_operations si_fops = {
 };
 
 
-static int si_configure_device( struct pci_dev *, const struct pci_device_id *);
-
-static int si_configure_device(pci, id)
-struct pci_dev *pci;
-const struct pci_device_id *id;
+static int si_configure_device(struct pci_dev *pci,
+                               const struct pci_device_id *id)
 {
   struct SIDEVICE *dev;
   unsigned char irup;
@@ -452,11 +449,7 @@ int si_close(struct inode *inode, struct file *filp) /* close */
 /* si_read polls data from uart */
 /* si_read does not block */
 
-ssize_t si_read( filp, buf, count, off )
-struct file *filp;
-char __user *buf;
-size_t count;
-loff_t *off;
+ssize_t si_read(struct file *filp, char __user *buf, size_t count, loff_t *off)
 {
   struct SIDEVICE *dev;
   int i, blocking, ret;
@@ -507,11 +500,8 @@ loff_t *off;
 /* si_write operates on the SI uart interface                       */
 /* if blocking then it blocks till done writing */
 
-ssize_t si_write(filp, buf, count, off )
-struct file *filp;
-const char __user *buf;
-size_t count;
-loff_t *off;
+ssize_t si_write(struct file *filp, const char __user *buf,
+                 size_t count, loff_t *off)
 {
   int i, ret, blocking;
   struct SIDEVICE *dev;
@@ -569,8 +559,7 @@ loff_t *off;
 
 /* true when UART transmit buffer is empty */
 
-int si_uart_tx_empty( dev )
-struct SIDEVICE *dev;
+int si_uart_tx_empty(struct SIDEVICE *dev)
 {
   unsigned long flags;
   int ret;
@@ -583,8 +572,7 @@ struct SIDEVICE *dev;
 
 /* true when UART has data */
 
-int si_uart_read_ready( dev )
-struct SIDEVICE *dev;
+int si_uart_read_ready(struct SIDEVICE *dev)
 {
   unsigned long flags;
   int ret;

--- a/driver/module.c
+++ b/driver/module.c
@@ -521,7 +521,7 @@ loff_t *off;
   blocking = (dev->Uart.block & SI_SERIAL_FLAGS_BLOCK)!=0;
 
   if( dev->verbose & SI_VERBOSE_SERIAL)
-    printk("SI write, count %d\n", count );
+    printk("SI write, count %lu\n", (unsigned long)count);
 
   if( dev->test ) {
     for (i=0; i < count; i++) {     // for all characters

--- a/driver/module.c
+++ b/driver/module.c
@@ -185,15 +185,10 @@ const struct pci_device_id *id;
       continue;
 
     dev->bar_len[i] = len;
-    if( IORESOURCE_IO & pci_resource_flags( pci, i ) ) { /* ports */
-      dev->bar[i] = pci_resource_start( pci, i );
-    } else {
-      dev->bar[i] = (__u32) ioremap_nocache(
-        pci_resource_start(pci,i), len );
-    }
+    dev->bar[i] = pci_iomap(pci, i, len);
 
     if( dev->verbose)
-      printk("SI address of bar %d: 0x%x\n", i, (unsigned int)dev->bar[i] );
+      printk("SI address of bar %d: 0x%lx\n", i, (unsigned long)dev->bar[i] );
   }
 
   if( pci->irq ) {

--- a/driver/module.c
+++ b/driver/module.c
@@ -1,6 +1,6 @@
-/* 
+/*
 
-Linux 2.6 Driver for the 
+Linux 2.6 Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen
@@ -46,12 +46,12 @@ MODULE_LICENSE("GPL");
 /* module parameters */
 
 /*
- if maxever is not zero on module load, 
+ if maxever is not zero on module load,
  configure memory based on buflen and maxever
 */
 
 int buflen = 1048576;
-module_param( buflen, int,  0 ); 
+module_param( buflen, int,  0 );
 
 int maxever = 33554432; /* this is for lotis */
 module_param( maxever, int,  0 );
@@ -60,7 +60,7 @@ int timeout = 5000;  /* default jiffies */
 module_param( timeout, int,  0 );
 
 int verbose = 0;
-module_param( verbose, int,  0 ); 
+module_param( verbose, int,  0 );
 
 
 #define SI_MAX_CARDS 3
@@ -174,7 +174,7 @@ static int si_configure_device(struct pci_dev *pci,
   pci_read_config_byte(dev->pci, PCI_INTERRUPT_LINE, &irup);
   if( (error = pci_request_regions( dev->pci, "SI3097")) < 0 )
     goto out;
-     
+
   for ( i=0; i<4; i++ ) {
     len = pci_resource_len(pci,i);
 
@@ -189,14 +189,14 @@ static int si_configure_device(struct pci_dev *pci,
   }
 
   if( pci->irq ) {
-    if((error = request_irq( 
+    if((error = request_irq(
        pci->irq, (void *)si_interrupt, IRQF_SHARED, "SI", dev))){
        printk( "SI %s failed to get irq %d error %d\n", pci_name(pci),
             pci->irq, error);
        printk( "SI skipping device\n");
        error = -ENODEV;
        goto out;
-     } 
+     }
   } else
     printk( "SI device %s no pci interupt\n", pci_name(pci) );
 
@@ -218,10 +218,10 @@ static int si_configure_device(struct pci_dev *pci,
   init_waitqueue_head( &dev->mmap_block );
 
   /* do the master reset local bus */
-//  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, 0 );  
+//  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, 0 );
 //  UART_REG_WRITE(dev, SERIAL_IER, 0);   /* disable all serial ints */
 //  mdelay(1);
-//  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, (LC_FIFO_MRS_L) );  
+//  LOCAL_REG_WRITE(dev, LOCAL_COMMAND, (LC_FIFO_MRS_L) );
 
 //  reg = PLX_REG8_READ(dev, PCI9054_DMA_COMMAND_STAT);
 //  printk("SI dma cmd stat 0x%x \n", reg );
@@ -235,7 +235,7 @@ static int si_configure_device(struct pci_dev *pci,
   PLX_REG_WRITE( dev, PCI9054_INT_CTRL_STAT, reg | (1 << 8) | (1<<11));
   reg = PLX_REG_READ( dev, PCI9054_INT_CTRL_STAT);
 
-//  printk("SI LOCAL_ID_NUMBER = 0x%x 0x%x\n", 
+//  printk("SI LOCAL_ID_NUMBER = 0x%x 0x%x\n",
 //    LOCAL_REG_READ(dev, LOCAL_ID_NUMBER), reg );
 
 //  reg = PLX_REG_READ( dev, PCI9054_INT_CTRL_STAT);
@@ -245,7 +245,7 @@ static int si_configure_device(struct pci_dev *pci,
 //    PLX_REG_WRITE( dev, PCI9054_INT_CTRL_STAT, reg | (1<<7) );
 //  }
 //  reg = PLX_REG_READ( dev, PCI9054_INT_CTRL_STAT );
-//  printk("SI LOCAL_REV_NUMBER = 0x%x 0x%x\n", 
+//  printk("SI LOCAL_REV_NUMBER = 0x%x 0x%x\n",
 //    LOCAL_REG_READ(dev, LOCAL_REV_NUMBER), reg );
 
 //  reg = PLX_REG_READ( dev, PCI9054_INT_CTRL_STAT);
@@ -360,7 +360,7 @@ static void __exit si_cleanup_module(void)
   for (nr = 0; nr < si_count; nr++) {
     dev = &si_devices[nr];
     si_stop_dma(dev, NULL);
-    si_free_sgl(dev);   
+    si_free_sgl(dev);
     si_cleanup_serial(dev);
     if( dev->pci ) {
       if( dev->pci->irq )
@@ -406,7 +406,7 @@ int si_open (struct inode *inode, struct file *filp)
   if( (op = atomic_read(&dev->isopen)) ) {
     printk("SI minor %d already open %d, thats ok\n", op, minor );
   }
-  
+
   filp->private_data = dev;
   atomic_inc(&dev->isopen);
 
@@ -434,7 +434,7 @@ int si_close(struct inode *inode, struct file *filp) /* close */
 //    }
     si_stop_dma(dev, NULL );
   }
-  
+
   if( atomic_read(&dev->isopen) <= 0 && atomic_read(&dev->vmact) != 0 ) {
     printk("SI close without vma_close, %d\n", atomic_read(&dev->vmact));
     atomic_set(&dev->vmact, 0);
@@ -442,7 +442,7 @@ int si_close(struct inode *inode, struct file *filp) /* close */
 
   filp->private_data = NULL;
   module_put(THIS_MODULE);
-    
+
   return 0;
 }
 
@@ -467,7 +467,7 @@ ssize_t si_read(struct file *filp, char __user *buf, size_t count, loff_t *off)
   }
 
   for (i=0; i < count; i++) {     // for all characters
-    
+
     while( si_receive_serial( dev, &ch ) == FALSE ) {
       if( !blocking ) {
         if( dev->verbose & SI_VERBOSE_SERIAL)
@@ -506,7 +506,7 @@ ssize_t si_write(struct file *filp, const char __user *buf,
   int i, ret, blocking;
   struct SIDEVICE *dev;
   __u8 ch;
- 
+
   dev = filp->private_data;
   blocking = (dev->Uart.block & SI_SERIAL_FLAGS_BLOCK)!=0;
 
@@ -524,10 +524,10 @@ ssize_t si_write(struct file *filp, const char __user *buf,
   for (i=0; i < count; i++) {     // for all characters
     if( get_user( ch, (char __user *)&buf[i] ) )
       return -EFAULT;
-    
+
     if( si_transmit_serial( dev, ch ) == FALSE ) {
       if( blocking ) {
- 
+
         ret = dev->Uart.timeout;
         wait_event_interruptible_timeout( dev->uart_wblock,
           si_uart_tx_empty( dev ), ret );

--- a/driver/si3097.h
+++ b/driver/si3097.h
@@ -24,7 +24,7 @@ struct SI_DMA_CONFIG {
 
 /* status word of SI_DMA_CONFIG */
 
-#define SI_DMA_CONFIG_WAKEUP_ONEND  0x01 
+#define SI_DMA_CONFIG_WAKEUP_ONEND  0x01
 #define SI_DMA_CONFIG_WAKEUP_EACH   0x02
 
 /* mask passed to verbose */
@@ -44,7 +44,7 @@ struct SI_DMA_STATUS {
 #define SI_DMA_STATUS_DONE     0x10
 #define SI_DMA_STATUS_ENABLE   0x01
 
-// UART configuration 
+// UART configuration
 
 struct SI_SERIAL_PARAM {
   int flags;
@@ -57,10 +57,10 @@ struct SI_SERIAL_PARAM {
   int timeout;
 };
 
-/* flags field for configuring the uart */ 
+/* flags field for configuring the uart */
 #define SI_SERIAL_FLAGS_BLOCK        0x04 /* read/write block for done */
 
-/* for SI_IOCTL_SETPOLL make poll (or select) wait on dma or the uart 
+/* for SI_IOCTL_SETPOLL make poll (or select) wait on dma or the uart
    but not both */
 
 #define SI_SETPOLL_DMA   0
@@ -101,7 +101,7 @@ typedef enum _SI_DRIVER_MSGS
 #define SI_IOCTL_SERIAL_BREAK      _IOW(SI_MAGIC, MSG_SI_SERIAL_BREAK, int)
 #define SI_IOCTL_SERIAL_CLEAR      _IO(SI_MAGIC, MSG_SI_SERIAL_CLEAR )
 #define SI_IOCTL_SERIAL_OUT_STATUS _IOR(SI_MAGIC, MSG_SI_SERIAL_OUT_STATUS, int)
-  
+
 #define SI_IOCTL_DMA_INIT          _IOR(SI_MAGIC, MSG_SI_DMA_INIT, struct SI_DMA_CONFIG )
 #define SI_IOCTL_DMA_START         _IOR(SI_MAGIC, MSG_SI_DMA_START, struct SI_DMA_STATUS )
 

--- a/driver/si3097_module.h
+++ b/driver/si3097_module.h
@@ -1,6 +1,6 @@
 
 /* This file holds the defines and internal structures
-   for the linux 2.6 driver for the
+   for the linux driver for the
    Spectral Instruments 3097 Interface card
 */
 

--- a/driver/si3097_module.h
+++ b/driver/si3097_module.h
@@ -33,7 +33,7 @@ struct SIDEVICE {
   spinlock_t dma_lock;     /* protection for dma registers  */
   spinlock_t nopage_lock;  /* protection for nopage/mmap  */
   atomic_t isopen;         /* true when device is open      */
-  __u32 bar[4];  /*  PCI bus address mappings */ 
+  void __iomem *bar[4];    /*  PCI bus address mappings */
   unsigned int bar_len[4]; /* length of PCI bus address mappings */
   atomic_t vmact;          /* number of vma opens */
 
@@ -77,26 +77,27 @@ struct SIDEVICE {
 
 
 // Macros for PLX chip register access
-#define PLX_REG_READ(pdx, offset)\
-  readl((__u32 *)((__u32)((pdx)->bar[0]) + (offset)))
+#define PLX_REG_READ(pdx, offset) \
+  ioread32((pdx)->bar[0] + (offset))
 #define PLX_REG_WRITE(pdx, offset, value) \
-  writel((value), (__u32 *)((__u32)((pdx)->bar[0]) + (offset)))
+  iowrite32((value), (pdx)->bar[0] + (offset))
 
-#define PLX_REG8_READ(pdx, offset)\
-  readb((__u32 *)((__u32)((pdx)->bar[0]) + (offset)))
+#define PLX_REG8_READ(pdx, offset) \
+  ioread8((pdx)->bar[0] + (offset))
 #define PLX_REG8_WRITE(pdx, offset, value) \
-  writeb((value), (__u32 *)((__u32)((pdx)->bar[0]) + (offset)))
+  iowrite8((value), (pdx)->bar[0] + (offset))
 
 // Macros for SI UART access
-#define UART_REG_READ(pdx, offset) inb(((__u32)((pdx)->bar[2])) + (offset))
-#define UART_REG_WRITE(pdx, offset, value)\
-  outb((value), ((__u32)((pdx)->bar[2])) + (offset))
+#define UART_REG_READ(pdx, offset) \
+  ioread8((pdx)->bar[2] + (offset))
+#define UART_REG_WRITE(pdx, offset, value) \
+  iowrite8((value), (pdx)->bar[2] + (offset))
 
 // Macros for SI LOCAL access
 #define LOCAL_REG_READ(pdx, offset) \
-  (inl(((__u32)((pdx)->bar[3])) + (offset*4)) & 0xff)
+  (ioread32((pdx)->bar[3] + (offset*4)) & 0xff)
 #define LOCAL_REG_WRITE(pdx, offset, value)\
-  outl((value & 0xff), ((__u32)((pdx)->bar[3])) + (offset*4))
+  iowrite32((value & 0xff), (pdx)->bar[3] + (offset*4))
 
 
 /*

--- a/driver/si3097_module.h
+++ b/driver/si3097_module.h
@@ -142,10 +142,8 @@ struct SIDMA_SGL {
   __u32 ladr;   /* DMA channel local address */
   __u32 siz;    /* transfer size (bytes) */
   __u32 dpr;    /* descriptor pointer */
-  __u32 cpu;    /* kernel virual address of padr */
-  __u32 fill;   /* pad out to 16-byte clean */
-  __u32 fill2;   /* pad out to 16-byte clean */
-  __u32 fill3;   /* pad out to 16-byte clean */
+  void *cpu;    /* kernel virual address of padr */
+  __u8 fill[16 - sizeof (void *)];   /* pad out to 16-byte clean */
 };
 
 

--- a/driver/si3097_module.h
+++ b/driver/si3097_module.h
@@ -65,15 +65,15 @@ struct SIDEVICE {
   __u32 rb_count;          /* local bus count at dma_done (must be zero) */
   int setpoll;             /* conditional for the function of select (poll)*/
   int alloc_maxever;       /* these must match dma_cfg */
-  int alloc_buflen;         
-  int alloc_nbuf;         
+  int alloc_buflen;
+  int alloc_nbuf;
   int alloc_sm_buflen;     /* dma_buflen padded out to PAGE_SIZE */
 };
 
 #define VMACLOSE_TIMEOUT (10*HZ)   /* seconds */
 
 // local address of the fifo read (no increment)
-#define SI_LOCAL_BUSADDR 0x30000004 
+#define SI_LOCAL_BUSADDR 0x30000004
 
 
 // Macros for PLX chip register access
@@ -102,11 +102,11 @@ struct SIDEVICE {
 
 /*
    This INTER_TYPE_* mask is used for the "source" word that
-   is passed to the bottom half of the interrupt service 
+   is passed to the bottom half of the interrupt service
    routine to tell what kind of interrupt occured
 */
 
-#define INTR_TYPE_NONE                  0 
+#define INTR_TYPE_NONE                  0
 #define INTR_TYPE_LOCAL_1               (1 << 0)
 #define INTR_TYPE_LOCAL_2               (1 << 1)
 #define INTR_TYPE_PCI_ABORT             (1 << 2)
@@ -118,7 +118,7 @@ struct SIDEVICE {
 #define INTR_TYPE_DMA_3                 (1 << 8)
 #define INTR_TYPE_SOFTWARE              (1 << 9)
 
-/* 
+/*
   these macros define the lower four bits
   of the SIDMA_SGL dpr register
 */
@@ -128,9 +128,9 @@ struct SIDEVICE {
 #define SIDMA_DPR_IRUP     0x04  /* true if irup desired after this block */
 #define SIDMA_DPR_TOPCI    0x08  /* true if direction is toward PCI bus */
 
-/* 
+/*
   This is the DMA Scatter Gather list
-  An array of these is allocated and populated 
+  An array of these is allocated and populated
   for each buffer requested by the DMA_INIT ioctl.
 
   fill is needed because the dpr register masks the
@@ -249,14 +249,14 @@ struct SIDMA_SGL {
 
 /*
   These registers are defined by SI and control
-  the DMA fifo.  They are mapped to BAR2 and are acessed 
+  the DMA fifo.  They are mapped to BAR2 and are acessed
   with the LOCAL_REG_[READ|WRITE] macros.
 */
 
 // defines for FIFOBaseRegisterAddress registers
 #define LOCAL_COMMAND        0 // local command register  (R/W)
 #define LOCAL_FIFO_SETUP     1 // access to FIFO setup register
-#define LOCAL_STATUS         2 // local status register    
+#define LOCAL_STATUS         2 // local status register
 #define LOCAL_UART           3 // local UART register
 
 #define LOCAL_ID_NUMBER      7 // ID number (104 for PC104 interface, 97 for PCI board PN 3097)
@@ -287,7 +287,7 @@ struct SIDMA_SGL {
 
 
 /*
-  These macros refer to registers mapped to 
+  These macros refer to registers mapped to
   BAR3 which control the 16550 UART serial port
   to the camera.
 */
@@ -307,8 +307,8 @@ struct SIDMA_SGL {
 #define SERIAL_MSR  6
 #define SERIAL_RAM  7
 
-#define TRUE  1 
-#define FALSE 0 
+#define TRUE  1
+#define FALSE 0
 
 
 // Function prototypes

--- a/driver/uart.c
+++ b/driver/uart.c
@@ -1,6 +1,6 @@
 /*
 
-Linux 2.6 Driver for the
+Linux Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen

--- a/driver/uart.c
+++ b/driver/uart.c
@@ -45,8 +45,7 @@ void si_get_serial_params(struct SIDEVICE *dev, struct SI_SERIAL_PARAM *sp)
   sp->buffersize  = dev->Uart.serialbufsize;
 }
 
-void si_uart_clear( dev ) 
-struct SIDEVICE *dev;
+void si_uart_clear(struct SIDEVICE *dev)
 {
   unsigned long flags;
   int clr;

--- a/driver/uart.c
+++ b/driver/uart.c
@@ -1,6 +1,6 @@
-/* 
+/*
 
-Linux 2.6 Driver for the 
+Linux 2.6 Driver for the
 Spectral Instruments 3097 Camera Interface
 
 Copyright (C) 2006  Jeffrey R Hagen
@@ -62,9 +62,9 @@ void si_uart_clear(struct SIDEVICE *dev)
 
 /* warn if clearing data */
   if( clr > 0 )
-    printk("SI UART clear rxcnt %d\n", clr ); 
+    printk("SI UART clear rxcnt %d\n", clr );
   else if( dev->verbose & SI_VERBOSE_SERIAL) {
-    printk("SI UART clear\n" ); 
+    printk("SI UART clear\n" );
   }
 }
 
@@ -103,7 +103,7 @@ int si_set_serial_params(struct SIDEVICE *dev, struct SI_SERIAL_PARAM *sp)
   UART_REG_WRITE(dev, SERIAL_LCR, c);
 
     // make sure the loop register is NOT set
-  UART_REG_WRITE(dev, SERIAL_MCR, 0);  
+  UART_REG_WRITE(dev, SERIAL_MCR, 0);
 
   dev->Uart.bits = sp->bits;
   x = (sp->bits - 1) & 3;
@@ -129,7 +129,7 @@ int si_set_serial_params(struct SIDEVICE *dev, struct SI_SERIAL_PARAM *sp)
   x = (sp->stopbits == 2)?4:0;
   c = UART_REG_READ(dev, SERIAL_LCR) & ~4;
   UART_REG_WRITE(dev, SERIAL_LCR, (__u8)(c | x));
-  
+
   switch (sp->fifotrigger) {
     case 1:
     case 4:
@@ -148,12 +148,12 @@ int si_set_serial_params(struct SIDEVICE *dev, struct SI_SERIAL_PARAM *sp)
 
   reg = UART_REG_READ(dev, SERIAL_FCR);
   if( dev->verbose & SI_VERBOSE_SERIAL)
-    printk("UART SERIAL_FCR 0x%x\n", reg ); 
+    printk("UART SERIAL_FCR 0x%x\n", reg );
 
   UART_REG_WRITE(dev, SERIAL_IER, 0);   /* disable all serial ints */
   cp = dev->Uart.rxbuf;  /* save old pointer just in case */
 
-  /* allocate one large buffer and split it in half. 
+  /* allocate one large buffer and split it in half.
      Allocatate new before deallocating old one.
    */
 
@@ -193,7 +193,7 @@ int si_set_serial_params(struct SIDEVICE *dev, struct SI_SERIAL_PARAM *sp)
   UART_REG_READ(dev, SERIAL_RX);
   reg = UART_REG_READ(dev, SERIAL_LSR);
   if( dev->verbose & SI_VERBOSE_SERIAL)
-    printk("UART SERIAL_LSR 0x%x\n", reg ); 
+    printk("UART SERIAL_LSR 0x%x\n", reg );
   UART_REG_READ(dev, SERIAL_MSR);
   UART_REG_WRITE(dev, SERIAL_IER, RX_INT|TX_INT);   /* tx ints enabled */
 
@@ -201,17 +201,17 @@ int si_set_serial_params(struct SIDEVICE *dev, struct SI_SERIAL_PARAM *sp)
 
   if( dev->verbose & SI_VERBOSE_SERIAL) {
     reg = UART_REG_READ(dev, SERIAL_IER);
-    printk("UART SERIAL_IER 0x%x\n", reg ); 
+    printk("UART SERIAL_IER 0x%x\n", reg );
   }
 
   if( dev->verbose & SI_VERBOSE_SERIAL) {
     reg = UART_REG_READ(dev, SERIAL_LCR);
-    printk("UART SERIAL_LCR 0x%x\n", reg ); 
+    printk("UART SERIAL_LCR 0x%x\n", reg );
   }
 
   if( dev->verbose & SI_VERBOSE_SERIAL) {
     reg = UART_REG_READ(dev, SERIAL_FCR);
-    printk("UART SERIAL_FCR 0x%x\n", reg ); 
+    printk("UART SERIAL_FCR 0x%x\n", reg );
   }
 
   si_uart_clear( dev );
@@ -233,8 +233,8 @@ int si_init_uart(struct SIDEVICE *dev)
   param.stopbits = 1;
   param.fifotrigger = 8;
   param.buffersize = PAGE_SIZE*2; /* 16384 */
-  
-  si_set_serial_params(dev, &param ); 
+
+  si_set_serial_params(dev, &param );
 
   if( dev->verbose & SI_VERBOSE_SERIAL)
     printk("exit initUART\n");
@@ -270,7 +270,7 @@ void si_cleanup_serial(struct SIDEVICE *dev)
     PLX_REG_WRITE( dev, PCI9054_INT_CTRL_STAT, reg & ~((1<<11)));
 }
 
-/* send one character over the serial bus 
+/* send one character over the serial bus
    if ready to send, send it, if not, queue
    and let the isr handle it
  */
@@ -308,13 +308,13 @@ int si_transmit_serial(struct SIDEVICE *dev, __u8 data)
   spin_unlock_irqrestore( &dev->uart_lock, flags );
 
 //  if( dev->verbose )
-//    printk( "SI transmit_serial 0x%x txcnt %d size %d reg 0x%x ret %d\n", 
+//    printk( "SI transmit_serial 0x%x txcnt %d size %d reg 0x%x ret %d\n",
 //     data, dev->Uart.txcnt, dev->Uart.serialbufsize, reg, ret );
 
   return ret;
 }
 
-/* read one character from UART 
+/* read one character from UART
 
    Remove 1 character from the receive queue, copy
    it into pdata, and return TRUE. If the queue
@@ -334,7 +334,7 @@ int si_receive_serial(struct SIDEVICE *dev, __u8 *pdata)
 
   spin_lock_irqsave( &dev->uart_lock, flags );
   reg = UART_REG_READ(dev, SERIAL_LSR);
- 
+
 
   if (dev->Uart.rxput != dev->Uart.rxget)
   {
@@ -348,7 +348,7 @@ int si_receive_serial(struct SIDEVICE *dev, __u8 *pdata)
     *pdata = 0;
     ret = FALSE;
   }
- 
+
   spin_unlock_irqrestore( &dev->uart_lock, flags );
 
   if( dev->verbose & SI_VERBOSE_SERIAL) {
@@ -396,13 +396,13 @@ int si_uart_break(struct SIDEVICE *dev, int break_time)
   spin_lock_irqsave( &dev->uart_lock, flags );
   uc = UART_REG_READ(dev, SERIAL_LCR);  // assert break (signal low)
   UART_REG_WRITE(dev, SERIAL_LCR, (__u8)(uc | 0x40));
-  
+
   mdelay(break_time);            // wait break time
-    
+
   uc = UART_REG_READ(dev, SERIAL_LCR);  // de-assert break (signal high)
   UART_REG_WRITE(dev, SERIAL_LCR, (__u8)(uc & ~0x40));
   spin_unlock_irqrestore( &dev->uart_lock, flags );
-  
+
   return(0);
 }
 


### PR DESCRIPTION
This PR fixes some issues that prevented the driver from working on x86_64 architecture, and that made it difficult for it to allocate its dma memory on a fragmented system.

Tested on linux-4.15.0 (on ubuntu bionic).