### PR TITLE
add travis build testing for driver and apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
     sources:
     packages:
       - libelf-dev
+      - linux-headers-3.13.0-100-generic
 
 script:
  - make -C driver check
+ - KERNEL_VERSION=3.13.0-100-generic make -C driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
     packages:
       - libelf-dev
       - linux-headers-3.13.0-100-generic
+      - libgtk2.0-dev
 
 script:
  - make -C driver check
  - KERNEL_VERSION=3.13.0-100-generic make -C driver
+ - make -C apps

--- a/apps/si-image.c
+++ b/apps/si-image.c
@@ -488,6 +488,7 @@ int main( int argc, char *argv[] )
   }
 
   gtk_main();
+  return 0;
 }
 
 /* just to see something pretty */


### PR DESCRIPTION
In addition to the just-added kernel style check, build the kernel module and the apps in travis to provide an additional sanity check (and portability check back to ubuntu 14.04) on PR's.