### PR TITLE
travis-ci: create build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,48 @@
 language: c
 
-sudo: false
-
 compiler:
   - gcc
 
-addons:
-  apt:
-    sources:
-    packages:
-      - libelf-dev
-      - linux-headers-3.13.0-100-generic
-      - libgtk2.0-dev
-
-script:
- - make -C driver check
- - KERNEL_VERSION=3.13.0-100-generic make -C driver
- - make -C apps
+jobs:
+  include:
+  - name: 'Run linux kernel checkpatch.pl script'
+    script: make -C driver check
+  - name: 'Build kernel module with linux-4.4.0 headers'
+    arch: amd64
+    dist: xenial
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.4.0-184-generic
+    script:
+    - KERNEL_VERSION=4.4.0-184-generic make -C driver
+  - name: 'Build kernel module with linux-4.4.0 headers'
+    arch: arm64
+    dist: xenial
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.4.0-184-generic
+    script:
+    - KERNEL_VERSION=4.4.0-184-generic make -C driver
+  - name: 'Build kernel module with linux-4.15.0 headers'
+    arch: amd64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.15.0-106-generic
+    script:
+    - KERNEL_VERSION=4.15.0-106-generic make -C driver
+  - name: 'Build kernel module with linux-4.15.0 headers'
+    arch: arm64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libelf-dev
+    - sudo apt-get -y install linux-headers-4.15.0-106-generic
+    script:
+    - KERNEL_VERSION=4.15.0-106-generic make -C driver
+  - name: 'Build test application on Ubuntu 18.04'
+    arch: amd64
+    dist: bionic
+    before_install:
+    - sudo apt-get -y install libgtk2.0-dev
+    script:
+    - make -C apps


### PR DESCRIPTION
Pull in .travis.yml changes from sbig-parport project,
which fixes a problem with missing kernel headers package,
and creates a build matrix to build on linux-4.4 and linux-4.15,
amd64 and arm64.

Build the si test apps on Ubuntu 18.04 amd64 only for now.